### PR TITLE
VictoriaMetrics has an URL part in the endpoint definition while Prometheus only has scheme://host:port. Allow both

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusAdapter.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusAdapter.java
@@ -12,8 +12,8 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.io.IOUtils;
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.HttpEntity;
-import org.apache.http.HttpHost;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -41,12 +41,12 @@ class PrometheusAdapter {
     private static final String STEP = "step";
 
     private final CloseableHttpClient _httpClient;
-    protected final HttpHost _prometheusEndpoint;
+    protected final URIBuilder _prometheusEndpoint;
     protected final int _samplingIntervalMs;
 
     PrometheusAdapter(CloseableHttpClient httpClient,
-                      HttpHost prometheusEndpoint,
-                      int samplingIntervalMs) {
+                    URIBuilder prometheusEndpoint,
+                    int samplingIntervalMs) {
         _httpClient = validateNotNull(httpClient, "httpClient cannot be null.");
         _prometheusEndpoint = validateNotNull(prometheusEndpoint, "prometheusEndpoint cannot be null.");
         _samplingIntervalMs = samplingIntervalMs;
@@ -59,7 +59,7 @@ class PrometheusAdapter {
     public List<PrometheusQueryResult> queryMetric(String queryString,
                                                    long startTimeMs,
                                                    long endTimeMs) throws IOException {
-        URI queryUri = URI.create(_prometheusEndpoint.toURI() + QUERY_RANGE_API_PATH);
+        URI queryUri = URI.create(_prometheusEndpoint.toString() + QUERY_RANGE_API_PATH);
         HttpPost httpPost = new HttpPost(queryUri);
 
         List<NameValuePair> data = new ArrayList<>();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusMetricSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusMetricSampler.java
@@ -114,7 +114,7 @@ public class PrometheusMetricSampler extends AbstractMetricSampler {
         } catch (URISyntaxException ex) {
             throw new ConfigException(
                 String.format("Prometheus endpoint URI is malformed, "
-                              + "expected schema://host:port[/uri], provided %s", endpoint), ex);
+                              + "expected schema://host:port[/path], provided %s", endpoint), ex);
         }
     }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusMetricSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusMetricSampler.java
@@ -5,11 +5,12 @@
 package com.linkedin.kafka.cruisecontrol.monitor.sampling.prometheus;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import org.apache.http.HttpHost;
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.kafka.common.Cluster;
@@ -106,16 +107,14 @@ public class PrometheusMetricSampler extends AbstractMetricSampler {
         }
 
         try {
-            HttpHost host = HttpHost.create(endpoint);
-            if (host.getPort() < 0) {
-                throw new IllegalArgumentException();
-            }
+            URIBuilder uriBuilder = new URIBuilder(endpoint);
+
             _httpClient = HttpClients.createDefault();
-            _prometheusAdapter = new PrometheusAdapter(_httpClient, host, _samplingIntervalMs);
-        } catch (IllegalArgumentException ex) {
+            _prometheusAdapter = new PrometheusAdapter(_httpClient, uriBuilder, _samplingIntervalMs);
+        } catch (URISyntaxException ex) {
             throw new ConfigException(
                 String.format("Prometheus endpoint URI is malformed, "
-                              + "expected schema://host:port, provided %s", endpoint), ex);
+                              + "expected schema://host:port[/uri], provided %s", endpoint), ex);
         }
     }
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusAdapterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusAdapterTest.java
@@ -11,9 +11,9 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.http.HttpEntity;
-import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.localserver.LocalServerTestBase;
 import org.apache.http.protocol.HttpContext;
@@ -44,7 +44,7 @@ public class PrometheusAdapterTest extends LocalServerTestBase {
             }
         });
 
-        HttpHost httpHost = this.start();
+        URIBuilder httpHost = new URIBuilder(this.start().toURI());
         PrometheusAdapter prometheusAdapter
             = new PrometheusAdapter(this.httpclient, httpHost, SAMPLING_INTERVAL_MS);
         final List<PrometheusQueryResult> prometheusQueryResults = prometheusAdapter.queryMetric(
@@ -136,7 +136,7 @@ public class PrometheusAdapterTest extends LocalServerTestBase {
             }
         });
 
-        HttpHost httpHost = this.start();
+        URIBuilder httpHost = new URIBuilder(this.start().toURI());
         PrometheusAdapter prometheusAdapter
             = new PrometheusAdapter(this.httpclient, httpHost, SAMPLING_INTERVAL_MS);
 
@@ -156,7 +156,7 @@ public class PrometheusAdapterTest extends LocalServerTestBase {
             }
         });
 
-        HttpHost httpHost = this.start();
+        URIBuilder httpHost = new URIBuilder(this.start().toURI());
         PrometheusAdapter prometheusAdapter
             = new PrometheusAdapter(this.httpclient, httpHost, SAMPLING_INTERVAL_MS);
 
@@ -176,7 +176,7 @@ public class PrometheusAdapterTest extends LocalServerTestBase {
             }
         });
 
-        HttpHost httpHost = this.start();
+        URIBuilder httpHost = new URIBuilder(this.start().toURI());
         PrometheusAdapter prometheusAdapter
             = new PrometheusAdapter(this.httpclient, httpHost, SAMPLING_INTERVAL_MS);
 
@@ -196,7 +196,7 @@ public class PrometheusAdapterTest extends LocalServerTestBase {
             }
         });
 
-        HttpHost httpHost = this.start();
+        URIBuilder httpHost = new URIBuilder(this.start().toURI());
         PrometheusAdapter prometheusAdapter
             = new PrometheusAdapter(this.httpclient, httpHost, SAMPLING_INTERVAL_MS);
 
@@ -216,7 +216,7 @@ public class PrometheusAdapterTest extends LocalServerTestBase {
             }
         });
 
-        HttpHost httpHost = this.start();
+        URIBuilder httpHost = new URIBuilder(this.start().toURI());
         PrometheusAdapter prometheusAdapter
             = new PrometheusAdapter(this.httpclient, httpHost, SAMPLING_INTERVAL_MS);
 
@@ -236,7 +236,7 @@ public class PrometheusAdapterTest extends LocalServerTestBase {
             }
         });
 
-        HttpHost httpHost = this.start();
+        URIBuilder httpHost = new URIBuilder(this.start().toURI());
         PrometheusAdapter prometheusAdapter
             = new PrometheusAdapter(this.httpclient, httpHost, SAMPLING_INTERVAL_MS);
 


### PR DESCRIPTION
This PR resolves #1917 .
