### PR TITLE
CVE fix: commons-lang3 v3.12.0 -> 3.20.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -322,6 +322,10 @@ project(':cruise-control') {
     constraints {
       implementation("commons-beanutils:commons-beanutils:1.11.0") {
         because("version 1.9.4 pulled from kafa 3.9.1 has CVE-2025-48734 in it, which is fixed in 1.11.0")
+        }
+        
+      implementation('org.apache.commons:commons-lang3:3.20.0') {
+        because("3.20.0 addresses vulnerability CVE-2025-48924")
       }
     }
 


### PR DESCRIPTION
Why:
Address CVE-2025-48924, a known vulnerability in org.apache.commons:commons-lang3.

What:
Added a Gradle constraint to enforce the use of commons-lang3 version 3.20.0, replacing the previously used 3.12.0, which is affected by the CVE.

Expected Behavior:
Vulnerability scans should no longer report the affected version of commons-lang3.
cruise-control should build successfully with the updated dependency.

Actual Behavior:
Vulnerability scanning no longer reports the affected version.
cruise-control builds successfully after the update.

Categorization:
security/CVE