### PR TITLE
Complete CVE fix for cruise-control-metrics-reporter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -473,6 +473,12 @@ project(':cruise-control-metrics-reporter') {
     // Temporary pin for vulnerability
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
 
+    constraints {
+      implementation("commons-beanutils:commons-beanutils:1.11.0") {
+        because("version 1.9.4 pulled from kafka 4.0.0 has CVE-2025-48734 in it, which is fixed in 1.11.0")
+      }
+    }
+    
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.9'


### PR DESCRIPTION
## Summary
1. Why: The fix for CVE-2025-48734 introduced in commit bea2bcbd was incomplete. It only added the dependency constraint to the `cruise-control` module but missed the `cruise-control-metrics-reporter` module. This resulted in the vulnerable commons-beanutils 1.9.4 JAR still being present in the container image at `/opt/cruise-control/libs/commons-beanutils-1.9.4.jar`.
2. What: This PR adds the missing dependency constraint to the `cruise-control-metrics-reporter` module, forcing Gradle to use commons-beanutils 1.11.0 (the patched version) instead of the vulnerable 1.9.4 that is transitively pulled by Apache Kafka 4.0.0.

## Actual Behavior
Currently in container image (built from commit bea2bcbd):
```bash
$ podman run --rm quay.io/strimzi/kafka:0.48.0-kafka-4.1.0 find / -name "commons-beanutils*.jar"
/opt/cruise-control/libs/commons-beanutils-1.9.4.jar  ❌ VULNERABLE
/opt/kafka/libs/commons-beanutils-1.11.0.jar          ✅
```

The vulnerable JAR is coming from the `cruise-control-metrics-reporter` module which lacks the dependency constraint.
