### PR TITLE
Minor refactor in start script to remove Kafka-related leftovers

### DIFF
--- a/kafka-cruise-control-start.sh
+++ b/kafka-cruise-control-start.sh
@@ -62,13 +62,13 @@ fi
 shopt -u nullglob
 
 # JMX settings
-if [ -z "$KAFKA_JMX_OPTS" ]; then
-  KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false  -Dcom.sun.management.jmxremote.ssl=false "
+if [ -z "$JMX_OPTS" ]; then
+  JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false  -Dcom.sun.management.jmxremote.ssl=false "
 fi
 
 # JMX port to use
 if [  $JMX_PORT ]; then
-  KAFKA_JMX_OPTS="$KAFKA_JMX_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT "
+  JMX_OPTS="$JMX_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT "
 fi
 
 # Log directory to use
@@ -77,12 +77,12 @@ if [ "x$LOG_DIR" = "x" ]; then
 fi
 
 # Log4j settings
-if [ -z "$KAFKA_LOG4J_OPTS" ]; then
+if [ -z "$LOG4J_OPTS" ]; then
   # Log to console. This is a tool.
   LOG4J_DIR="$base_dir/config/log4j.properties"
   # If Cygwin is detected, LOG4J_DIR is converted to Windows format.
   (( CYGWIN )) && LOG4J_DIR=$(cygpath --path --mixed "${LOG4J_DIR}")
-  KAFKA_LOG4J_OPTS="-Dlog4j.configurationFile=file:${LOG4J_DIR}"
+  LOG4J_OPTS="-Dlog4j.configurationFile=file:${LOG4J_DIR}"
 else
   # create logs directory
   if [ ! -d "$LOG_DIR" ]; then
@@ -90,17 +90,13 @@ else
   fi
 fi
 
-# If Cygwin is detected, LOG_DIR is converted to Windows format.
-(( CYGWIN )) && LOG_DIR=$(cygpath --path --mixed "${LOG_DIR}")
-KAFKA_LOG4J_OPTS="-Dkafka.logs.dir=$LOG_DIR $KAFKA_LOG4J_OPTS"
-
 # Generic jvm settings you want to add
-if [ -z "$KAFKA_OPTS" ]; then
-  KAFKA_OPTS=""
+if [ -z "$JVM_OPTS" ]; then
+  JVM_OPTS=""
 fi
 
 # Set Debug options if enabled
-if [ "x$KAFKA_DEBUG" != "x" ]; then
+if [ "x$DEBUG" != "x" ]; then
 
     # Use default ports
     DEFAULT_JAVA_DEBUG_PORT="5005"
@@ -116,7 +112,7 @@ if [ "x$KAFKA_DEBUG" != "x" ]; then
     fi
 
     echo "Enabling Java debug options: $JAVA_DEBUG_OPTS"
-    KAFKA_OPTS="$JAVA_DEBUG_OPTS $KAFKA_OPTS"
+    JVM_OPTS="$JAVA_DEBUG_OPTS $JVM_OPTS"
 fi
 
 # Which java to use
@@ -127,19 +123,19 @@ else
 fi
 
 # Memory options
-if [ -z "$KAFKA_HEAP_OPTS" ]; then
-  KAFKA_HEAP_OPTS="-Xmx1G"
+if [ -z "$HEAP_OPTS" ]; then
+  HEAP_OPTS="-Xmx1G"
 fi
 
 # JVM performance options
-if [ -z "$KAFKA_JVM_PERFORMANCE_OPTS" ]; then
-  KAFKA_JVM_PERFORMANCE_OPTS="-server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+DisableExplicitGC -Djava.awt.headless=true"
+if [ -z "$JVM_PERFORMANCE_OPTS" ]; then
+  JVM_PERFORMANCE_OPTS="-server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+DisableExplicitGC -Djava.awt.headless=true"
 fi
 
-#Add jaas file to KAFKA_OPTS if present
+#Add jaas file to JVM_OPTS if present
 if [ -f $base_dir/config/cruise_control_jaas.conf ]
 then
-  KAFKA_OPTS="-Djava.security.auth.login.config=$base_dir/config/cruise_control_jaas.conf $KAFKA_OPTS"
+  JVM_OPTS="-Djava.security.auth.login.config=$base_dir/config/cruise_control_jaas.conf $JVM_OPTS"
 fi
 
 DAEMON_NAME="kafka-cruise-control"
@@ -153,7 +149,7 @@ while [ $# -gt 0 ]; do
       shift 2
       ;;
     -loggc)
-      if [ -z "$KAFKA_GC_LOG_OPTS" ]; then
+      if [ -z "$GC_LOG_OPTS" ]; then
         GC_LOG_ENABLED="true"
       fi
       shift
@@ -178,7 +174,7 @@ GC_FILE_SUFFIX='-gc.log'
 GC_LOG_FILE_NAME=''
 if [ "x$GC_LOG_ENABLED" = "xtrue" ]; then
   GC_LOG_FILE_NAME=$DAEMON_NAME$GC_FILE_SUFFIX
-  KAFKA_GC_LOG_OPTS="-Xloggc:$LOG_DIR/$GC_LOG_FILE_NAME -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=100M"
+  GC_LOG_OPTS="-Xloggc:$LOG_DIR/$GC_LOG_FILE_NAME -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=100M"
 fi
 
 # If Cygwin is detected, classpath is converted to Windows format.
@@ -186,7 +182,7 @@ fi
 
 # Launch mode
 if [ "x$DAEMON_MODE" = "xtrue" ]; then
-  nohup $JAVA $KAFKA_HEAP_OPTS $KAFKA_JVM_PERFORMANCE_OPTS $KAFKA_GC_LOG_OPTS $KAFKA_JMX_OPTS $KAFKA_LOG4J_OPTS -cp $CLASSPATH $KAFKA_OPTS com.linkedin.kafka.cruisecontrol.KafkaCruiseControlMain "$@" > "$CONSOLE_OUTPUT_FILE" 2>&1 < /dev/null &
+  nohup $JAVA $HEAP_OPTS $JVM_PERFORMANCE_OPTS $GC_LOG_OPTS $JMX_OPTS $LOG4J_OPTS -cp $CLASSPATH $JVM_OPTS com.linkedin.kafka.cruisecontrol.KafkaCruiseControlMain "$@" > "$CONSOLE_OUTPUT_FILE" 2>&1 < /dev/null &
 else
-  exec $JAVA $KAFKA_HEAP_OPTS $KAFKA_JVM_PERFORMANCE_OPTS $KAFKA_GC_LOG_OPTS $KAFKA_JMX_OPTS $KAFKA_LOG4J_OPTS -cp $CLASSPATH $KAFKA_OPTS com.linkedin.kafka.cruisecontrol.KafkaCruiseControlMain "$@"
+  exec $JAVA $HEAP_OPTS $JVM_PERFORMANCE_OPTS $GC_LOG_OPTS $JMX_OPTS $LOG4J_OPTS -cp $CLASSPATH $JVM_OPTS com.linkedin.kafka.cruisecontrol.KafkaCruiseControlMain "$@"
 fi

--- a/kafka-cruise-control-start.sh
+++ b/kafka-cruise-control-start.sh
@@ -61,6 +61,15 @@ else
 fi
 shopt -u nullglob
 
+# Backward compatibility for deprecated KAFKA_* env vars (remove after migration)
+: "${JMX_OPTS:=${KAFKA_JMX_OPTS:-}}"
+: "${LOG4J_OPTS:=${KAFKA_LOG4J_OPTS:-}}"
+: "${JVM_OPTS:=${KAFKA_OPTS:-}}"
+: "${HEAP_OPTS:=${KAFKA_HEAP_OPTS:-}}"
+: "${JVM_PERFORMANCE_OPTS:=${KAFKA_JVM_PERFORMANCE_OPTS:-}}"
+: "${GC_LOG_OPTS:=${KAFKA_GC_LOG_OPTS:-}}"
+: "${DEBUG:=${KAFKA_DEBUG:-}}"
+
 # JMX settings
 if [ -z "$JMX_OPTS" ]; then
   JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false  -Dcom.sun.management.jmxremote.ssl=false "


### PR DESCRIPTION
## What

CC's start script defines variables with a `KAFKA_` prefix which is incorrect. This is likely a leftover from copy-pasting Kafka start scripts. 😁 

Looking at [kafka-run-class.sh](https://github.com/apache/kafka/blob/trunk/bin/kafka-run-class.sh) and [kafka-server-start.sh](https://github.com/apache/kafka/blob/trunk/bin/kafka-server-start.sh) further supports my claim. Lol.

## Why

Might cause a confusion when reading the code, especially to an engineer that's new to the codebase.

## Categorization
- [ ] documentation
- [ ] bugfix
- [ ] new feature
- [x] refactor
- [ ] security/CVE
- [ ] other

