### PR TITLE
Upgrade swagger-parser-v3 to 2.1.17+ to fix CVE-2024-47554 in commons-io

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -304,7 +304,7 @@ project(':cruise-control') {
     implementation "org.eclipse.jetty:jetty-server:${jettyVersion}"
     implementation 'io.dropwizard.metrics:metrics-jmx:4.2.9'
     implementation 'com.nimbusds:nimbus-jose-jwt:10.0.2'
-    implementation 'io.swagger.parser.v3:swagger-parser-v3:2.1.16'
+    implementation 'io.swagger.parser.v3:swagger-parser-v3:2.1.22'
     implementation 'io.github.classgraph:classgraph:4.8.141'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
     // Temporary pin for vulnerability


### PR DESCRIPTION


## Summary
1. Why: To resolve issue #2363 .
2. What: Upgrade swagger-parser-v3 to 2.1.17+ to fix CVE-2024-47554 in commons-io.

## Expected Behavior
The project should use a version of commons-io (2.14.0+) that is not vulnerable to CVE-2024-47554 (Uncontrolled Resource Consumption vulnerability)

## Actual Behavior
The project currently uses swagger-parser-v3:2.1.16, which transitively depends on commons-io:2.11.0, a version vulnerable to CVE-2024-47554.

## Steps to Reproduce
1. Run `./gradlew dependencies --configuration runtimeClasspath | grep commons-io`
2. Observe commons-io:2.11.0 is pulled in via swagger-parser-v3:2.1.16
3. Check CVE database for commons-io:2.11.0 vulnerabilities

## Known Workarounds
Upgrade is required to fix the vulnerability.

## Additional evidence
1. **CVE-2024-47554**: Uncontrolled Resource Consumption in Apache Commons IO
   - Fixed in: commons-io 2.14.0+
2. **Dependency chain**: cruise-control → swagger-parser-v3:2.1.16 → commons-io:2.11.0
3. **Solution**: swagger-parser-v3:2.1.17+ uses commons-io:2.14.0+
4. **Upgrade**: Changed from 2.1.16 to 2.1.22 (latest stable)

## Categorization
- [ ] documentation
- [ ] bugfix
- [ ] new feature
- [ ] refactor
- [x ] security/CVE
- [ ] other

This PR resolves #2363 .
