### PR TITLE
Update commons-io to 2.14.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -332,7 +332,7 @@ project(':cruise-control') {
     testImplementation 'org.easymock:easymock:5.5.0'
     testImplementation "org.apache.kafka:kafka_$scalaBinaryVersion:$kafkaVersion:test"
     testImplementation "org.apache.kafka:kafka-clients:$kafkaVersion:test"
-    testImplementation 'commons-io:commons-io:2.14.0'
+    testImplementation 'commons-io:commons-io:2.22.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13:tests'
     testImplementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
     testImplementation 'org.apache.kerby:kerb-simplekdc:2.1.0'
@@ -483,7 +483,7 @@ project(':cruise-control-metrics-reporter') {
     testImplementation "org.apache.kafka:kafka-metadata:$kafkaVersion"
     testImplementation "org.apache.kafka:kafka-raft:$kafkaVersion"
     testImplementation "org.apache.kafka:kafka-storage:$kafkaVersion"
-    testImplementation 'commons-io:commons-io:2.14.0'
+    testImplementation 'commons-io:commons-io:2.22.0'
     testImplementation "org.testcontainers:kafka:$testcontainersVersion"
     testOutput sourceSets.test.output
   }

--- a/build.gradle
+++ b/build.gradle
@@ -332,7 +332,7 @@ project(':cruise-control') {
     testImplementation 'org.easymock:easymock:5.5.0'
     testImplementation "org.apache.kafka:kafka_$scalaBinaryVersion:$kafkaVersion:test"
     testImplementation "org.apache.kafka:kafka-clients:$kafkaVersion:test"
-    testImplementation 'commons-io:commons-io:2.11.0'
+    testImplementation 'commons-io:commons-io:2.14.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13:tests'
     testImplementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
     testImplementation 'org.apache.kerby:kerb-simplekdc:2.1.0'
@@ -483,7 +483,7 @@ project(':cruise-control-metrics-reporter') {
     testImplementation "org.apache.kafka:kafka-metadata:$kafkaVersion"
     testImplementation "org.apache.kafka:kafka-raft:$kafkaVersion"
     testImplementation "org.apache.kafka:kafka-storage:$kafkaVersion"
-    testImplementation 'commons-io:commons-io:2.11.0'
+    testImplementation 'commons-io:commons-io:2.14.0'
     testImplementation "org.testcontainers:kafka:$testcontainersVersion"
     testOutput sourceSets.test.output
   }


### PR DESCRIPTION
## Summary
1. Why: `commons-io:2.11.0` is pinned directly in `build.gradle` for two subprojects and is affected by CVE-2024-47554 (Uncontrolled Resource Consumption in `XmlStreamReader`).
2. What: Bump both `testImplementation 'commons-io:commons-io:2.11.0'` declarations in `build.gradle` to `2.14.0`.

## Expected Behavior
`commons-io:2.14.0` is resolved for both `cruise-control` and `cruise-control-metrics-reporter` subprojects, eliminating the CVE-2024-47554 exposure from the direct dependency pin.

## Actual Behavior
`commons-io:2.11.0` is pinned directly in `build.gradle` (lines 335 and 486), which is vulnerable to CVE-2024-47554.

## Steps to Reproduce
1. Run `./gradlew dependencies | grep commons-io` — resolves to `2.11.0`.
2. After this fix, the same command resolves to `2.14.0`.

## Known Workarounds
None

## Additional evidence
1. CVE details: https://nvd.nist.gov/vuln/detail/CVE-2024-47554

## Categorization
- [ ] documentation
- [ ] bugfix
- [ ] new feature
- [ ] refactor
- [x] security/CVE
- [ ] other

This PR resolves #2383.
