### PR TITLE
Fix Prometheus query timestamp formatting

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusAdapter.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusAdapter.java
@@ -6,6 +6,7 @@ package com.linkedin.kafka.cruisecontrol.monitor.sampling.prometheus;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigDecimal;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -68,8 +69,8 @@ class PrometheusAdapter {
          They accept values with a decimal point (up to 64 bits). The samples returned are inclusive of the "end"
          timestamp provided.
          */
-        data.add(new BasicNameValuePair(START, String.valueOf((double) startTimeMs / SEC_TO_MS)));
-        data.add(new BasicNameValuePair(END, String.valueOf((double) endTimeMs / SEC_TO_MS)));
+        data.add(new BasicNameValuePair(START, BigDecimal.valueOf(startTimeMs, 3).toPlainString()));
+        data.add(new BasicNameValuePair(END, BigDecimal.valueOf(endTimeMs, 3).toPlainString()));
         // step is expected to be in seconds, and accept values with a decimal point (up to 64 bits).
         data.add(new BasicNameValuePair(STEP, String.valueOf((double) _samplingIntervalMs / SEC_TO_MS)));
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusAdapterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusAdapterTest.java
@@ -9,15 +9,20 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpHost;
+import org.apache.http.NameValuePair;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.localserver.LocalServerTestBase;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.HttpRequestHandler;
+import org.apache.http.util.EntityUtils;
 import org.junit.Test;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.prometheus.model.PrometheusMetric;
 import com.linkedin.kafka.cruisecontrol.monitor.sampling.prometheus.model.PrometheusQueryResult;
@@ -25,12 +30,15 @@ import com.linkedin.kafka.cruisecontrol.monitor.sampling.prometheus.model.Promet
 
 import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.SEC_TO_MS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class PrometheusAdapterTest extends LocalServerTestBase {
     private static final long START_TIME_SECS = 1603301400L;
     private static final long END_TIME_SECS = 1603301459L;
     private static final long START_TIME_MS = START_TIME_SECS * SEC_TO_MS;
     private static final long END_TIME_MS = END_TIME_SECS * SEC_TO_MS;
+    private static final long PLAIN_TIMESTAMP_START_TIME_MS = 1784144612388L;
+    private static final long PLAIN_TIMESTAMP_END_TIME_MS = 1784148212388L;
     private static final int SAMPLING_INTERVAL_MS = (int) TimeUnit.SECONDS.toMillis(30);
     private static final int ONE_KB = 1024;
 
@@ -53,6 +61,41 @@ public class PrometheusAdapterTest extends LocalServerTestBase {
 
         assertEquals(expectedResults().toString(), prometheusQueryResults.toString());
         assertEquals(expectedResults(), prometheusQueryResults);
+    }
+
+    @Test
+    public void testQueryTimestampsUsePlainDecimalNotation() throws Exception {
+        AtomicReference<List<NameValuePair>> requestParameters = new AtomicReference<>();
+        this.serverBootstrap.registerHandler(PrometheusAdapter.QUERY_RANGE_API_PATH, new HttpRequestHandler() {
+            @Override
+            public void handle(HttpRequest request, HttpResponse response, HttpContext context) throws IOException {
+                HttpEntity requestEntity = ((HttpEntityEnclosingRequest) request).getEntity();
+                String requestBody = EntityUtils.toString(requestEntity, StandardCharsets.UTF_8);
+                requestParameters.set(URLEncodedUtils.parse(requestBody, StandardCharsets.UTF_8));
+                response.setStatusCode(HttpServletResponse.SC_OK);
+                response.setEntity(buildSuccessResponseEntity());
+            }
+        });
+
+        HttpHost httpHost = this.start();
+        PrometheusAdapter prometheusAdapter
+            = new PrometheusAdapter(this.httpclient, httpHost, SAMPLING_INTERVAL_MS);
+        prometheusAdapter.queryMetric("up", PLAIN_TIMESTAMP_START_TIME_MS, PLAIN_TIMESTAMP_END_TIME_MS);
+
+        String start = parameterValue(requestParameters.get(), "start");
+        String end = parameterValue(requestParameters.get(), "end");
+        assertEquals("1784144612.388", start);
+        assertEquals("1784148212.388", end);
+        assertFalse(start.matches(".*[Ee].*"));
+        assertFalse(end.matches(".*[Ee].*"));
+    }
+
+    private static String parameterValue(List<NameValuePair> parameters, String name) {
+        return parameters.stream()
+            .filter(parameter -> name.equals(parameter.getName()))
+            .map(NameValuePair::getValue)
+            .findFirst()
+            .orElse(null);
     }
 
     private static HttpEntity buildSuccessResponseEntity() {


### PR DESCRIPTION
## Summary
1. Why: `PrometheusAdapter` serializes Unix timestamps through `Double.toString()`, which emits scientific notation for current epoch values. Scientific notation is outside the documented Prometheus range-query timestamp format and is rejected by stricter compatible backends such as VictoriaMetrics.
2. What: serialize `start` and `end` directly from epoch milliseconds with `BigDecimal.toPlainString()`, and add a regression test that inspects the real URL-encoded POST body.

## Expected Behavior
`PrometheusMetricSampler` sends exact plain-decimal Unix timestamps, such as
`1784144612.388`, so Prometheus-compatible range-query backends can parse them.

## Actual Behavior
The previous implementation sent values such as `1.784144612388E9`.
VictoriaMetrics rejects that value with HTTP 422, so sampling fails and no monitored
windows are populated.

## Steps to Reproduce
1. Configure `prometheus.server.endpoint` to use a VictoriaMetrics endpoint.
2. Start Cruise Control with `PrometheusMetricSampler`.
3. Observe `/api/v1/query_range` receive an exponent-form `start`/`end` value and
   return HTTP 422.

The added regression test reproduces the serialization issue without requiring an
external Prometheus-compatible service.

## Known Workarounds
Use a backend that leniently accepts exponent-form timestamps. There is no Cruise
Control configuration that changes the previous timestamp serialization.

## Additional evidence
1. Environment: macOS arm64, Eclipse Temurin JDK 17.0.20.
2. Before the production change, the new regression test failed deterministically:
   expected `1784144612.388`, but received `1.784144612388E9`.
3. After the change, all 29 tests in the Prometheus sampling package pass, including
   a clean run from a fresh clone of the public branch.
4. The same Gradle verification also completed Checkstyle, SpotBugs, and
   JaCoCo report generation successfully.

## Categorization
- [ ] documentation
- [x] bugfix
- [ ] new feature
- [ ] refactor
- [ ] security/CVE
- [ ] other

This PR resolves #2389.
