### PR TITLE
CircleCI: Remove badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@ Cruise Control for Apache Kafka
 ===================
 
 [![CI](https://github.com/linkedin/cruise-control/actions/workflows/ci.yaml/badge.svg)](https://github.com/linkedin/cruise-control/actions/workflows/ci.yaml)
-[![CircleCI](https://circleci.com/gh/linkedin/cruise-control.svg?style=svg)](https://circleci.com/gh/linkedin/cruise-control)
-
 
 ### Introduction ###
   Cruise Control is a product that helps run Apache Kafka clusters at large scale. Due to the popularity of 


### PR DESCRIPTION


## Summary
1. Why: circle CI integration had been removed in #2391: this is a follow up to cleanup remaining artifacts
2. What: Removed CircleCI badge from the README file.

## Expected Behavior
No circle CI badge in the Readme

## Actual Behavior
Circle CI badge in the Readme and failing

## Steps to Reproduce
see [Readme](/Readme.md)

## Known Workarounds
n/a

## Additional evidence
<img width="554" height="107" alt="image" src="https://github.com/user-attachments/assets/95a28534-e7a4-464a-83fd-7980008eb878" />
 
## Categorization
- [x] documentation
- [ ] bugfix
- [ ] new feature
- [ ] refactor
- [ ] security/CVE
- [ ] other