### PR TITLE
Added documentation for the remove_disks endpoint in docs/wiki/User G…

### DIFF
--- a/docs/wiki/User Guide/REST-APIs.md
+++ b/docs/wiki/User Guide/REST-APIs.md
@@ -526,7 +526,7 @@ Supported parameters are:
 | brokerid_and_logdirs      | list      | list of broker id and logdir pairs for disks to remove from the cluster                           | N/A                   | **no**    |
 | dryrun                    | boolean   | whether dry-run the request or not                                                                | true                  | yes       |
 | stop_ongoing_execution    | boolean   | whether to stop the ongoing execution (if any) and start executing the given request              | false                 | yes       |
-| reason                    | string    | reason for the request                                                                            | "No reason provided"  | yes       |
+| reason                    | string    | reason for the request; required for non-dry-run requests when `request.reason.required` is enabled               | "No reason provided" when not required | conditional |
 | json                      | boolean   | return in JSON format or not                                                                      | false                 | yes       |
 
 Note that `brokerid_and_logdirs` takes comma as delimiter between two broker id and logdir pairs — i.e. we assume a valid logdir name contains no comma. Each pair uses a hyphen (`-`) as the delimiter between broker id and logdir name (e.g. `101-/tmp/kafka-logs-1`).

--- a/docs/wiki/User Guide/REST-APIs.md
+++ b/docs/wiki/User Guide/REST-APIs.md
@@ -16,6 +16,7 @@
     * [Decommission a list of brokers from the Kafka cluster](#decommission-a-list-of-brokers-from-the-kafka-cluster)
     * [Fix offline replicas in Kafka cluster](#fix-offline-replicas-in-kafka-cluster)
     * [Demote a list of brokers from the Kafka cluster](#demote-a-list-of-brokers-from-the-kafka-cluster)
+    * [Remove disks from brokers in the Kafka cluster](#remove-disks-from-brokers-in-the-kafka-cluster)
     * [Stop the current proposal execution task](#stop-the-current-proposal-execution-task)
     * [Pause metrics load sampling](#pause-metrics-load-sampling)
     * [Resume metrics load sampling](#resume-metrics-load-sampling)
@@ -312,6 +313,7 @@ The post requests of Kafka Cruise Control REST API are operations that will have
 * [Decommission a list of brokers from the Kafka cluster](#decommission-a-list-of-brokers-from-the-kafka-cluster)
 * [Fix offline replicas in Kafka cluster](#fix-offline-replicas-in-kafka-cluster)
 * [Demote a list of brokers from the Kafka cluster](#demote-a-list-of-brokers-from-the-kafka-cluster)
+* [Remove disks from brokers in the Kafka cluster](#remove-disks-from-brokers-in-the-kafka-cluster)
 * [Stop the current proposal execution task](#stop-the-current-proposal-execution-task)
 * [Pause metrics load sampling](#pause-metrics-load-sampling)
 * [Resume metrics load sampling](#resume-metrics-load-sampling)
@@ -508,8 +510,38 @@ Demoting a broker/disk is consist of tow steps.
 
 Set `skip_urp_demotion` to false will cancel outstanding operations if partitions stay under replicated; Set `exclude_follower_demotion` will skip operations on the partitions which only have follower replicas on the brokers/disks to be demoted. The purpose of the former is to prevent the URP recovery process from blocking the demotion execution, the latter ensures that the demotion operation is limited to leaders.
 
+### Remove disks from brokers in the Kafka cluster
+The following POST request moves all replicas from the specified disks to the remaining disks on the same broker. This enables decommissioning individual disks in a JBOD Kafka deployment without removing the entire broker.
+
+    POST /kafkacruisecontrol/remove_disks?brokerid_and_logdirs=[id1-logdir1,id1-logdir2...]
+
+For example, to remove two disks from broker `101`:
+
+    POST /kafkacruisecontrol/remove_disks?brokerid_and_logdirs=101-/tmp/kafka-logs-1,101-/tmp/kafka-logs-2&dryrun=false
+
+Supported parameters are:
+
+| PARAMETER                 | TYPE      | DESCRIPTION                                                                                       | DEFAULT               | OPTIONAL  |
+|---------------------------|-----------|---------------------------------------------------------------------------------------------------|-----------------------|-----------|
+| brokerid_and_logdirs      | list      | list of broker id and logdir pairs for disks to remove from the cluster                           | N/A                   | **no**    |
+| dryrun                    | boolean   | whether dry-run the request or not                                                                | true                  | yes       |
+| stop_ongoing_execution    | boolean   | whether to stop the ongoing execution (if any) and start executing the given request              | false                 | yes       |
+| reason                    | string    | reason for the request                                                                            | "No reason provided"  | yes       |
+| json                      | boolean   | return in JSON format or not                                                                      | false                 | yes       |
+
+Note that `brokerid_and_logdirs` takes comma as delimiter between two broker id and logdir pairs — i.e. we assume a valid logdir name contains no comma. Each pair uses a hyphen (`-`) as the delimiter between broker id and logdir name (e.g. `101-/tmp/kafka-logs-1`).
+
+Unlike most other optimization endpoints, `remove_disks` does not accept a `goals` parameter. Proposal generation always uses `IntraBrokerDiskCapacityGoal` with disk-emptying enabled, regardless of the `intra.broker.goals` or `default.goals` configuration. This goal generates intra-broker replica movement proposals to move all replicas off the specified disks while keeping each remaining disk under the configured capacity threshold.
+
+Before generating proposals, Cruise Control validates that:
+* Each specified logdir exists on the corresponding broker.
+* At least one logdir remains on each affected broker.
+* The remaining disk capacity on each affected broker is sufficient to absorb the load from the disks being removed (based on the configured disk capacity threshold).
+
+Replica movements are limited to disks within the same broker — there is no inter-broker replica movement. `stop_ongoing_execution` and `dryrun` cannot both be set to `true`.
+
 ### Stop the current proposal execution task
-The following POST request will let Kafka Cruise Control stop an ongoing `rebalance`, `add_broker`,  `remove_broker`, `fix_offline_replica`, `topic_configuration` or `demote_broker` operation:
+The following POST request will let Kafka Cruise Control stop an ongoing `rebalance`, `add_broker`,  `remove_broker`, `fix_offline_replica`, `topic_configuration`, `demote_broker` or `remove_disks` operation:
 
     POST /kafkacruisecontrol/stop_proposal_execution
 


### PR DESCRIPTION
## Summary

1. **Why:** The `remove_disks` REST API endpoint is already implemented and registered as a POST endpoint, but it was missing from the `REST-APIs.md` documentation. This made it difficult for users to discover and understand how to use the endpoint.
2. **What:** Added documentation for the `remove_disks` endpoint to `guide/REST-APIs.md`, including its usage, supported parameters, request example, disk/logdir format, validation behavior, replica movement behavior, and the fixed `IntraBrokerDiskCapacityGoal` used for proposal generation.

## Expected Behavior

The REST API documentation should provide complete information about the `remove_disks` endpoint, including its required and optional parameters, example usage, and relevant behavior and restrictions.

## Actual Behavior

The `remove_disks` endpoint was implemented and available, but there was no corresponding section in the REST API documentation.

## Steps to Reproduce

1. Open `guide/REST-APIs.md`.
2. Look through the documented POST endpoints.
3. Observe that the `remove_disks` endpoint was not previously documented.

## Known Workarounds

N/A. The endpoint could be used by referring to the implementation, but there was no dedicated REST API documentation for it.

## Additional evidence

1. Added `remove_disks` to the POST API table of contents.
2. Documented the endpoint and an example request using `brokerid_and_logdirs`.
3. Added the parameter table covering `brokerid_and_logdirs`, `dryrun`, `stop_ongoing_execution`, `reason`, and `json`.
4. Documented the `IntraBrokerDiskCapacityGoal`, validation requirements, and same-broker replica movement behavior.

## Categorization

* [x] documentation
* [ ] bugfix
* [ ] new feature
* [ ] refactor
* [ ] security/CVE
* [ ] other

This PR resolves #2361.
