### PR TITLE
Fix Vert.x webserver implementation to respect `webserver.security.enable` setting

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/vertx/MainVerticle.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/vertx/MainVerticle.java
@@ -78,6 +78,10 @@ public class MainVerticle extends AbstractVerticle {
   }
 
   private Router buildRouter(RouterBuilder builder) {
+    if (!_asynckafkaCruiseControl.config().getBoolean(WebServerConfig.WEBSERVER_SECURITY_ENABLE_CONFIG)) {
+      builder.securityHandler("basicAuth", RoutingContext::next);
+      builder.securityHandler("jwtAuth", RoutingContext::next);
+    }
     builder.operation("state").handler(_endPoints::handle);
     builder.operation("kafkaClusterState").handler(_endPoints::handle);
     builder.operation("load").handler(_endPoints::handle);


### PR DESCRIPTION
## Summary

1. Why: When `webserver.security.enable=false` the Vert.x web server path enforces authentication because the OpenAPI spec (`base.yaml`) declares a global `security` requirement (as of https://github.com/cruise-control-for-kafka/cruise-control/pull/2395). The Vert.x `RouterBuilder` reads this and rejects unauthenticated requests with 401, regardless of the Cruise Control security config.

2. What: Register no-op security handlers in `MainVerticle.buildRouter()` when `webserver.security.enable=false`, so the Vert.x path respects the same config flag as the servlet path.

## Expected Behavior

 When `webserver.security.enable=false`, all Cruise Control REST endpoints should be accessible without authentication, regardless of whether Vert.x is enabled.

## Actual Behavior

With Vert.x enabled, all endpoints return 401 even when `webserver.security.enable=false`, because the OpenAPI spec's global `security: - basicAuth: []` block is enforced by the `RouterBuilder`.

## Steps to Reproduce

1. Set `webserver.security.enable=false` and `vertx.enabled=true` in `cruisecontrol.properties`
2. Start Cruise Control
3. Call any REST endpoint (e.g. `/kafkaclusterstate`) without credentials
4. Observe 401 response

## Known Workarounds

Remove the global `security` block from `base.yaml`, or disable Vert.x with `vertx.enabled=false`.

## Additional evidence

1. Integration tests `BrokerFailureIntegrationTest.testBrokerFailure[0]` and `DiskFailureIntegrationTest.testDiskFailure[0]` (Vert.x enabled) fail with assertion errors due to silent 401 responses, while `[1]` (Vert.x disabled) passes.

## Categorization
- [ ] documentation
- [x] bugfix
- [ ] new feature
- [ ] refactor
- [ ] security/CVE
- [ ] other